### PR TITLE
Introduce GenerationHandle and enhance benchmark app

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "thirdparty/openvino_tokenizers"]
     path = thirdparty/openvino_tokenizers
     url = https://github.com/openvinotoolkit/openvino_tokenizers.git
+    branch = master

--- a/text_generation/causal_lm/cpp/continuous_batching/Dockerfile
+++ b/text_generation/causal_lm/cpp/continuous_batching/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:22.04
+
+ARG JOBS
+WORKDIR /workspace
+RUN apt-get update -y && apt-get install -y python3-pip python3-venv git
+
+# Install OpenVINO
+RUN git clone https://github.com/openvinotoolkit/openvino.git && \
+    cd /workspace/openvino && \
+    git submodule update --init -- /workspace/openvino/thirdparty/xbyak /workspace/openvino/thirdparty/pugixml /workspace/openvino/thirdparty/open_model_zoo \
+        /workspace/openvino/thirdparty/protobuf /workspace/openvino/thirdparty/snappy /workspace/openvino/thirdparty/telemetry /workspace/openvino/src/plugins/intel_cpu/thirdparty/mlas \
+        /workspace/openvino/src/plugins/intel_cpu/thirdparty/onednn /workspace/openvino/src/bindings/python/thirdparty/pybind11 && cd -
+
+RUN /workspace/openvino/install_build_dependencies.sh
+RUN python3 -m pip install -r /workspace/openvino/src/bindings/python/wheel/requirements-dev.txt
+RUN cmake -DENABLE_PYTHON=ON -DENABLE_PYTHON_PACKAGING=ON -DENABLE_WHEEL=ON -DENABLE_CPPLINT=OFF -DENABLE_SAMPLES=OFF -DENABLE_INTEL_GPU=OFF \
+        -DENABLE_INTEL_NPU=OFF -DENABLE_TEMPLATE=OFF -DENABLE_AUTO=OFF -DENABLE_HETERO=OFF -DENABLE_AUTO_BATCH=OFF -DENABLE_OV_TF_FRONTEND=ON -DENABLE_OV_ONNX_FRONTEND=OFF \
+        -DENABLE_OV_TF_LITE_FRONTEND=OFF -DENABLE_OV_PADDLE_FRONTEND=OFF -S /workspace/openvino -B /workspace/openvino_build
+RUN cmake --build /workspace/openvino_build --parallel $JOBS
+RUN cmake -P /workspace/openvino_build/cmake_install.cmake
+RUN python3 -m pip install /workspace/openvino_build/wheels/openvino-2024* 
+ENV OpenVINO_DIR=/workspace/openvino_build
+
+# Download dataset
+RUN wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
+
+# Build continuous batching library
+RUN git clone --branch request_rate https://github.com/mzegla/openvino.genai.git && cd /workspace/openvino.genai/text_generation/causal_lm/cpp/continuous_batching && \
+        git submodule update --remote --init && cmake -DCMAKE_BUILD_TYPE=Release -S ./ -B ./build/ && cmake --build ./build/ -j $JOBS
+
+# Install test dependencies
+RUN python3 -m pip install --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly/ /workspace/openvino.genai/thirdparty/openvino_tokenizers
+RUN PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" python3 -m pip install -r /workspace/openvino.genai/text_generation/causal_lm/cpp/continuous_batching/python/tests/requirements.txt
+ENV PYTHONPATH=/workspace/openvino.genai/text_generation/causal_lm/cpp/continuous_batching/build/python

--- a/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
@@ -53,8 +53,8 @@ int main(int argc, char* argv[]) try {
     };
 
     std::vector<GenerationConfig> sampling_params_examples {
-         GenerationConfig::beam_search(),
-         GenerationConfig::greedy(),
+        GenerationConfig::beam_search(),
+        GenerationConfig::greedy(),
         // GenerationConfig::multinomial(),
     };
 
@@ -88,17 +88,17 @@ int main(int argc, char* argv[]) try {
         std::cout << "Question: " << prompts[request_id] << std::endl;
         switch (generation_result.m_status)
         {
-        case GenerationResultStatus::FINISHED:
+        case GenerationStatus::FINISHED:
             print_generation_result(generation_result);
             break;
-        case GenerationResultStatus::IGNORED:
+        case GenerationStatus::IGNORED:
             std::cout << "Request was ignored due to lack of memory." <<std::endl;
             if (generation_result.m_generation_ids.size() > 0) {
                 std::cout << "Partial result:" << std::endl;
                 print_generation_result(generation_result);
             }
             break;
-        case GenerationResultStatus::ABORTED:
+        case GenerationStatus::DROPPED_BY_PIPELINE:
             std::cout << "Request was aborted." <<std::endl;
             if (generation_result.m_generation_ids.size() > 0) {
                 std::cout << "Partial result:" << std::endl;

--- a/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
@@ -55,7 +55,7 @@ int main(int argc, char* argv[]) try {
     std::vector<GenerationConfig> sampling_params_examples {
         GenerationConfig::beam_search(),
         GenerationConfig::greedy(),
-        // GenerationConfig::multinomial(),
+        GenerationConfig::multinomial(),
     };
 
     std::vector<std::string> prompts(num_prompts);

--- a/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
@@ -5,6 +5,7 @@
 #include <cxxopts.hpp>
 
 #include "continuous_batching_pipeline.hpp"
+#include "tokenizer.hpp"
 
 void print_generation_result(const GenerationResult& generation_result) {
     for (size_t output_id = 0; output_id < generation_result.m_generation_ids.size(); ++output_id) {
@@ -46,14 +47,14 @@ int main(int argc, char* argv[]) try {
     std::vector<std::string> prompt_examples = {
         "What is OpenVINO?",
         "How are you?",
-        "What is OpenVINO?",
-        "What is the current time",
+        "What is your name?",
+        "Tell me something about Canada",
         "What is OpenVINO?",
     };
 
     std::vector<GenerationConfig> sampling_params_examples {
-        GenerationConfig::beam_search(),
-        // GenerationConfig::greedy(),
+         GenerationConfig::beam_search(),
+         GenerationConfig::greedy(),
         // GenerationConfig::multinomial(),
     };
 
@@ -66,7 +67,7 @@ int main(int argc, char* argv[]) try {
     }
 
     // Perform the inference
-
+    
     SchedulerConfig scheduler_config {
         // batch size
         .max_num_batched_tokens = 32,
@@ -84,7 +85,6 @@ int main(int argc, char* argv[]) try {
 
     for (size_t request_id = 0; request_id < generation_results.size(); ++request_id) {
         const GenerationResult & generation_result = generation_results[request_id];
-
         std::cout << "Question: " << prompts[request_id] << std::endl;
         switch (generation_result.m_status)
         {
@@ -110,7 +110,6 @@ int main(int argc, char* argv[]) try {
         }
         std::cout << std::endl;
     }
-
 } catch (const std::exception& error) {
     std::cerr << error.what() << '\n';
     return EXIT_FAILURE;

--- a/text_generation/causal_lm/cpp/continuous_batching/apps/throughput_benchmark.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/apps/throughput_benchmark.cpp
@@ -404,7 +404,7 @@ int main(int argc, char* argv[]) try {
     // Perform the first inference
     SchedulerConfig scheduler_config {
         .max_num_batched_tokens = max_batch_size,
-        .num_kv_blocks = 1500,
+        .cache_size = 100,
         .block_size = 32,
         .dynamic_split_fuse = dynamic_split_fuse,
         .max_num_seqs = 256, // not used if dynamic_split_fuse=True

--- a/text_generation/causal_lm/cpp/continuous_batching/library/CMakeLists.txt
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/CMakeLists.txt
@@ -40,7 +40,7 @@ add_library(openvino::continuous_batching ALIAS openvino_continuous_batching)
 
 target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src"
                                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_compile_definitions(${TARGET_NAME} PRIVATE OPENVINO_TOKENIZERS_PATH=\"$<TARGET_FILE:openvino_tokenizers>\")
+target_compile_definitions(${TARGET_NAME} PRIVATE OPENVINO_TOKENIZERS_PATH="libopenvino_tokenizers.so")
 set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON)
 
 target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime PRIVATE nlohmann_json::nlohmann_json)

--- a/text_generation/causal_lm/cpp/continuous_batching/library/CMakeLists.txt
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TARGET_NAME openvino_continuous_batching)
 add_library(${TARGET_NAME} STATIC
     src/tokenizer.cpp
     src/generation_config.cpp
+    src/generation_handle.cpp
     src/continuous_batching_pipeline.cpp
     src/paged_attention_transformations.cpp)
 
@@ -40,7 +41,7 @@ add_library(openvino::continuous_batching ALIAS openvino_continuous_batching)
 target_include_directories(${TARGET_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src"
                                           PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_compile_definitions(${TARGET_NAME} PRIVATE OPENVINO_TOKENIZERS_PATH=\"$<TARGET_FILE:openvino_tokenizers>\")
-set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 11 CXX_STANDARD_REQUIRED ON)
+set_target_properties(${TARGET_NAME} PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED ON)
 
 target_link_libraries(${TARGET_NAME} PUBLIC openvino::runtime PRIVATE nlohmann_json::nlohmann_json)
 

--- a/text_generation/causal_lm/cpp/continuous_batching/library/include/continuous_batching_pipeline.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/include/continuous_batching_pipeline.hpp
@@ -27,9 +27,7 @@ public:
 
     void step();
 
-    bool has_running_requests() const;
-
-    bool has_awaiting_requests() const;
+    bool has_non_finished_requests();
 
     // more high level interface, which can process multiple prompts in continuous batching manner
     std::vector<GenerationResult> generate(const std::vector<std::string>& prompts, std::vector<GenerationConfig> sampling_params);

--- a/text_generation/causal_lm/cpp/continuous_batching/library/include/continuous_batching_pipeline.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/include/continuous_batching_pipeline.hpp
@@ -3,31 +3,13 @@
 
 #pragma once
 
+#include <memory>
 #include <openvino/openvino.hpp>
 
 #include "scheduler_config.hpp"
 #include "tokenizer.hpp"
 #include "generation_config.hpp"
-
-enum class GenerationResultStatus {
-    FINISHED = 0,
-    IGNORED = 1,
-    ABORTED = 2 // Currently not used, TODO: implement abort functionality
-};
-
-struct GenerationResult {
-    // request ID
-    uint64_t m_request_id;
-
-    // in a generic case we have multiple generation results per initial prompt
-    // depending on sampling parameters (e.g. beam search or parallel sampling)
-    std::vector<std::string> m_generation_ids;
-    // scores
-    std::vector<float> m_scores;
-
-    // Status of generation
-    GenerationResultStatus m_status;
-};
+#include "generation_handle.hpp"
 
 class ContinuousBatchingPipeline {
     class Impl;
@@ -41,11 +23,13 @@ public:
 
     GenerationConfig get_config() const;
 
-    void add_request(uint64_t request_id, std::string prompt, GenerationConfig sampling_params);
+    GenerationHandle add_request(uint64_t request_id, std::string prompt, GenerationConfig sampling_params);
 
-    std::vector<GenerationResult> step();
+    void step();
 
     bool has_running_requests() const;
+
+    bool has_awaiting_requests() const;
 
     // more high level interface, which can process multiple prompts in continuous batching manner
     std::vector<GenerationResult> generate(const std::vector<std::string>& prompts, std::vector<GenerationConfig> sampling_params);

--- a/text_generation/causal_lm/cpp/continuous_batching/library/include/generation_handle.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/include/generation_handle.hpp
@@ -1,0 +1,68 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "generation_config.hpp"
+
+
+enum class GenerationResultStatus {
+    FINISHED = 0,
+    IGNORED = 1,
+    ABORTED = 2 // Currently not used, TODO: implement abort functionality
+};
+
+struct GenerationResult {
+    // request ID - obsolete when handle API is approved as handle will connect results with prompts.
+    uint64_t m_request_id;
+
+    // in a generic case we have multiple generation results per initial prompt
+    // depending on sampling parameters (e.g. beam search or parallel sampling)
+    std::vector<std::string> m_generation_ids;
+    // scores
+    std::vector<float> m_scores;
+
+    // Status of generation
+    GenerationResultStatus m_status;
+};
+
+struct GenerationOutput {
+    std::vector<int64_t> generated_token_ids;
+    float score;
+};
+
+using GenerationOutputs = std::unordered_map<uint64_t, GenerationOutput>;
+
+class GenerationStream;
+
+class GenerationHandleImpl {
+    std::shared_ptr<GenerationStream> m_generation_stream;
+    GenerationConfig m_sampling_params;
+ 
+public:
+    GenerationHandleImpl(std::shared_ptr<GenerationStream> generation_stream, const GenerationConfig& sampling_params) :
+    m_generation_stream(generation_stream),
+    m_sampling_params(sampling_params) {};
+
+    ~GenerationHandleImpl();
+
+    // There can be only one handle for a request
+    GenerationHandleImpl(const GenerationHandleImpl&) = delete;
+    GenerationHandleImpl& operator=(const GenerationHandleImpl&) = delete;
+
+    bool generation_finished();
+
+    GenerationResultStatus get_finish_status();
+
+    bool can_read();
+
+    // Reads result of a generation for single iteration
+    GenerationOutputs read();
+    // Reads all generated tokens for all sequences
+    std::vector<GenerationOutput> read_all();
+};
+
+using GenerationHandle = std::unique_ptr<GenerationHandleImpl>;

--- a/text_generation/causal_lm/cpp/continuous_batching/library/include/generation_handle.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/include/generation_handle.hpp
@@ -9,10 +9,12 @@
 #include "generation_config.hpp"
 
 
-enum class GenerationResultStatus {
-    FINISHED = 0,
-    IGNORED = 1,
-    ABORTED = 2 // Currently not used, TODO: implement abort functionality
+enum class GenerationStatus {
+    RUNNING = 0, // Default status for ongoing generation
+    FINISHED = 1, // Status set when generation has been finished
+    IGNORED = 2, // Status set when generation run into out-of-memory condition and could not be continued
+    DROPPED_BY_PIPELINE = 3, // Currently not used, TODO: implement abort functionality
+    DROPPED_BY_HANDLE = 4 // Status set when generation handle is dropped
 };
 
 struct GenerationResult {
@@ -26,7 +28,7 @@ struct GenerationResult {
     std::vector<float> m_scores;
 
     // Status of generation
-    GenerationResultStatus m_status;
+    GenerationStatus m_status = GenerationStatus::RUNNING;
 };
 
 struct GenerationOutput {
@@ -53,9 +55,7 @@ public:
     GenerationHandleImpl(const GenerationHandleImpl&) = delete;
     GenerationHandleImpl& operator=(const GenerationHandleImpl&) = delete;
 
-    bool generation_finished();
-
-    GenerationResultStatus get_finish_status();
+    GenerationStatus get_status();
 
     bool can_read();
 

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/continuous_batching_pipeline.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/continuous_batching_pipeline.cpp
@@ -202,20 +202,12 @@ public:
             timer.end();
         }
 
-        // perform post-processing of current step
+        // free non running requests for current step
 
         {
-            static ManualTimer timer("create finished results");
+            static ManualTimer timer("free non running requests");
             timer.start();
-
-            for (size_t i = 0; i < scheduler_output.m_scheduled_sequence_groups_ids.size(); ++i) {
-                uint64_t seq_group_id = scheduler_output.m_scheduled_sequence_groups_ids[i];
-                SequenceGroup::Ptr sequence_group = m_requests[seq_group_id];
-                sequence_group->notify_handle();
-            }
-
             _free_non_running_requests();
-
             timer.end();
         }
 

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_handle.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_handle.cpp
@@ -37,6 +37,7 @@ void add_partial_result(std::unordered_map<uint64_t, GenerationOutput>& partial_
 std::vector<GenerationOutput> GenerationHandleImpl::read_all() {
     std::vector<GenerationOutput> results;
     std::unordered_map<uint64_t, GenerationOutput> partial_results;
+    // We iterate until generation is running or there are tokens we haven't read yet
     while (get_status() == GenerationStatus::RUNNING || can_read()) {
         // For unary case there's only one iteration and we get all results in a single read() call
         std::unordered_map<uint64_t, GenerationOutput> iteration_results = read();

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_handle.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_handle.cpp
@@ -10,12 +10,8 @@ GenerationHandleImpl::~GenerationHandleImpl() {
     m_generation_stream->drop();
 }
 
-bool GenerationHandleImpl::generation_finished() {
-    return m_generation_stream->generation_finished();
-}
-
-GenerationResultStatus GenerationHandleImpl::get_finish_status() {
-    return m_generation_stream->get_finish_status();
+GenerationStatus GenerationHandleImpl::get_status() {
+    return m_generation_stream->get_status();
 }
 
 bool GenerationHandleImpl::can_read() {
@@ -41,7 +37,7 @@ void add_partial_result(std::unordered_map<uint64_t, GenerationOutput>& partial_
 std::vector<GenerationOutput> GenerationHandleImpl::read_all() {
     std::vector<GenerationOutput> results;
     std::unordered_map<uint64_t, GenerationOutput> partial_results;
-    while (!generation_finished() || can_read()) {
+    while (get_status() == GenerationStatus::RUNNING || can_read()) {
         // For unary case there's only one iteration and we get all results in a single read() call
         std::unordered_map<uint64_t, GenerationOutput> iteration_results = read();
         add_partial_result(partial_results, iteration_results);

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_handle.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_handle.cpp
@@ -1,0 +1,54 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <openvino/openvino.hpp>
+
+#include "generation_handle.hpp"
+#include "generation_stream.hpp"
+
+GenerationHandleImpl::~GenerationHandleImpl() {
+    m_generation_stream->drop();
+}
+
+bool GenerationHandleImpl::generation_finished() {
+    return m_generation_stream->generation_finished();
+}
+
+GenerationResultStatus GenerationHandleImpl::get_finish_status() {
+    return m_generation_stream->get_finish_status();
+}
+
+bool GenerationHandleImpl::can_read() {
+    return m_generation_stream->can_read();
+}
+
+std::unordered_map<uint64_t, GenerationOutput> GenerationHandleImpl::read() {
+    return m_generation_stream->read();
+}
+
+void add_partial_result(std::unordered_map<uint64_t, GenerationOutput>& partial_results, std::unordered_map<uint64_t, GenerationOutput>& iteration_results) {
+    for (auto& iteration_result: iteration_results) {
+        auto partial_result_iter = partial_results.find(iteration_result.first);
+        if (partial_result_iter == partial_results.end()) {
+            partial_results.emplace(iteration_result.first, iteration_result.second);
+        } else {
+            partial_result_iter->second.generated_token_ids.push_back(iteration_result.second.generated_token_ids[0]);
+            partial_result_iter->second.score = iteration_result.second.score;
+        }
+    }
+}
+
+std::vector<GenerationOutput> GenerationHandleImpl::read_all() {
+    std::vector<GenerationOutput> results;
+    std::unordered_map<uint64_t, GenerationOutput> partial_results;
+    while (!generation_finished() || can_read()) {
+        // For unary case there's only one iteration and we get all results in a single read() call
+        std::unordered_map<uint64_t, GenerationOutput> iteration_results = read();
+        add_partial_result(partial_results, iteration_results);
+    }
+
+    for (auto& partial_result: partial_results) {
+        results.push_back(partial_result.second);
+    }
+    return results;
+}

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_stream.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_stream.hpp
@@ -1,0 +1,69 @@
+// Copyright (C) 2023-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+#include <mutex>
+#include <atomic>
+#include "continuous_batching_pipeline.hpp"
+#include "synchronized_queue.hpp"
+#include "generation_handle.hpp"
+
+
+class GenerationStream {
+    std::mutex m_mutex;
+    bool m_handle_dropped = false;
+    bool m_generation_finished = false;
+    GenerationResultStatus m_finish_status;
+    SynchronizedQueue<GenerationOutputs> m_output_queue;
+
+    std::vector<uint64_t> last_sequence_ids;
+
+public:
+    using Ptr = std::shared_ptr<GenerationStream>;
+
+    // Don't use directly
+    GenerationStream() = default;
+
+    static GenerationStream::Ptr create() {
+        return std::make_shared<GenerationStream>();
+    }
+
+    void push(GenerationOutputs outputs) {
+        m_output_queue.push(outputs);
+    }
+
+    // Retriving vector of pairs <sequence_id, token_id> as we can generate multiple outputs for a single prompt
+    GenerationOutputs read() {
+        return m_output_queue.pull();
+    }
+
+    bool can_read() {
+        return !m_output_queue.empty();
+    }
+
+    void finish_generation_stream(GenerationResultStatus status) {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_generation_finished = true;
+        m_finish_status = status;
+    }
+
+    bool generation_finished() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_generation_finished;
+    }
+
+    GenerationResultStatus get_finish_status() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_finish_status;
+    }
+
+    void drop() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_handle_dropped = true;
+    }
+
+    bool handle_dropped() {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_handle_dropped;
+    }
+};

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_stream.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/generation_stream.hpp
@@ -11,9 +11,7 @@
 
 class GenerationStream {
     std::mutex m_mutex;
-    bool m_handle_dropped = false;
-    bool m_generation_finished = false;
-    GenerationResultStatus m_finish_status;
+    GenerationStatus m_status = GenerationStatus::RUNNING;
     SynchronizedQueue<GenerationOutputs> m_output_queue;
 
     std::vector<uint64_t> last_sequence_ids;
@@ -41,29 +39,18 @@ public:
         return !m_output_queue.empty();
     }
 
-    void finish_generation_stream(GenerationResultStatus status) {
+    void set_generation_status(GenerationStatus status) {
         std::lock_guard<std::mutex> lock(m_mutex);
-        m_generation_finished = true;
-        m_finish_status = status;
+        m_status = status;
     }
 
-    bool generation_finished() {
+    GenerationStatus get_status() {
         std::lock_guard<std::mutex> lock(m_mutex);
-        return m_generation_finished;
-    }
-
-    GenerationResultStatus get_finish_status() {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return m_finish_status;
+        return m_status;
     }
 
     void drop() {
         std::lock_guard<std::mutex> lock(m_mutex);
-        m_handle_dropped = true;
-    }
-
-    bool handle_dropped() {
-        std::lock_guard<std::mutex> lock(m_mutex);
-        return m_handle_dropped;
+        m_status = GenerationStatus::DROPPED_BY_HANDLE;
     }
 };

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/sampler.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/sampler.hpp
@@ -457,6 +457,9 @@ SamplerOutput Sampler::sample(std::vector<SequenceGroup::Ptr> & sequence_groups,
                     m_beam_search_info.at(request_id).finalize(sampler_output);
                 }
             }
+            // Notify handle after sampling is done. 
+            // For non-streaming this is effective only when the generation is finished.
+            sequence_group->notify_handle();
         } else {
             // we are in prompt processing phase when prompt is split into chunks and processed step by step
         }

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
@@ -62,6 +62,7 @@ public:
         if (scheduler_output.m_total_num_scheduled_tokens == 0) {
             for (size_t sequence_group_id = 0; sequence_group_id < sequence_groups.size(); ++sequence_group_id) {
                 sequence_groups[sequence_group_id]->set_out_of_memory();
+                sequence_groups[sequence_group_id]->finish_generation_stream(GenerationResultStatus::IGNORED);
             }
         }
         return scheduler_output;

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
@@ -56,15 +56,6 @@ public:
         }
 
         _clear_waiting_sequences(sequence_groups);
-
-
-        // if no tokens were scheduled, we are out of memory
-        if (scheduler_output.m_total_num_scheduled_tokens == 0) {
-            for (size_t sequence_group_id = 0; sequence_group_id < sequence_groups.size(); ++sequence_group_id) {
-                sequence_groups[sequence_group_id]->set_out_of_memory();
-                sequence_groups[sequence_group_id]->finish_generation_stream(GenerationResultStatus::IGNORED);
-            }
-        }
         return scheduler_output;
     }
 

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/sequence_group.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/sequence_group.hpp
@@ -447,20 +447,10 @@ public:
         } else if (m_sampling_params.is_greedy_sampling() || m_sampling_params.is_multinomial()) {
             // TO DO: Now we always stream for greedy search for the sake of benchmarking
             if (true /* m_sampling_params.stream */) {
-                // If sequence group has been preempted we skip retriving the results as seqeunce tokens have not been cleared and
-                // there's no new token. We reset preemption flag, so when it's scheduled again we process it normally.
-                if (m_preempted) {
-                    m_preempted = false;
-                    return;
-                }
                 for (auto& sequence : m_sequences) {
-                    if (sequence->get_generated_len() > 0) {
                         outputs.emplace(sequence->get_grouped_id(), sequence->get_last_generation_output(m_sampling_params));
-                    }
                 }
-                if (outputs.size()) {
-                    m_generation_stream->push(outputs);
-                }
+                m_generation_stream->push(outputs);
             }
         }
 

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/synchronized_queue.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/synchronized_queue.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+
+template <typename T>
+class SynchronizedQueue
+{
+    std::queue<T> m_queue;
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+
+public:
+    SynchronizedQueue() = default;
+    SynchronizedQueue(const SynchronizedQueue&) = delete;
+    SynchronizedQueue(const SynchronizedQueue&&) = delete;
+    SynchronizedQueue& operator=(const SynchronizedQueue&) = delete;
+
+    T pull() {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_cv.wait(lock, [this]{return !m_queue.empty();});
+        auto val = m_queue.front();
+        m_queue.pop();
+        return val;
+    }
+
+    void push(const T& item) {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_queue.push(item);
+        m_cv.notify_one();
+    }
+
+    bool empty() {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        return m_queue.empty();
+    }
+};

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/tokenizer.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/tokenizer.cpp
@@ -2,17 +2,99 @@
 // Copyright (C) 2023-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+#include <mutex>
+#include <queue>
 #include "openvino/runtime/core.hpp"
 
 #include "tokenizer.hpp"
 
-class Tokenizer::Impl {
-    const size_t TOKENIZER_BATCH_SIZE = 1;
-    ov::InferRequest m_tokenizer, m_detokenizer;
-    std::size_t m_eos_token_id;
+/*
+class InferenceRunner {
 
 public:
-    explicit Impl(const std::string& models_path) {
+    std::queue<std::size_t> m_free_ir_indexes;
+    std::vector<ov::InferRequest> m_infer_requests;
+    std::shared_ptr<ov::Model> m_model;
+    std::mutex m_mutex; // protecting the free ir indexes queue
+
+    explicit InferenceRunner(std::string model_path) {
+        ov::Core core;
+        core.add_extension(OPENVINO_TOKENIZERS_PATH);  // OPENVINO_TOKENIZERS_PATH is defined in CMakeLists.txt
+        m_model = core.read_model(model_path);
+        ov::CompiledModel compiled_model = core.compile_model(m_model, "CPU");
+        for (int i = 0; i < 128; i++) {
+            m_infer_requests.push_back(compiled_model.create_infer_request());
+            m_free_ir_indexes.push(i);
+        }
+    }
+};
+
+class TokenizerRunner : public InferenceRunner {
+public:
+    using InferenceRunner::InferenceRunner;
+
+    ov::Tensor run(std::string& prompt) {
+        int free_ir_index;
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            free_ir_index = m_free_ir_indexes.front();
+            m_free_ir_indexes.pop();
+        }
+        m_infer_requests[free_ir_index].set_input_tensor(ov::Tensor{ov::element::string, {1}, &prompt});
+        m_infer_requests[free_ir_index].infer();
+        ov::Tensor output = m_infer_requests[free_ir_index].get_tensor("input_ids");
+
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_free_ir_indexes.push(free_ir_index);
+        return output;
+    }
+
+    std::size_t get_eos_token_id() {
+        const ov::AnyMap& rt_info = m_model->get_rt_info();
+        OPENVINO_ASSERT(rt_info.find("eos_token_id") != rt_info.end(), "Failed to detect \"eos_token_id\" in openvino_tokenizer.xml runtime information");
+        return rt_info.at("eos_token_id").as<int64_t>();
+    }
+};
+
+
+class DetokenizerRunner : public InferenceRunner {
+public:
+    using InferenceRunner::InferenceRunner;
+
+    std::string run(std::vector<int64_t>& tokens) {
+        int free_ir_index;
+        {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            free_ir_index = m_free_ir_indexes.front();
+            m_free_ir_indexes.pop();
+        }
+        m_infer_requests[free_ir_index].set_input_tensor(ov::Tensor{ov::element::i64, {1, tokens.size()}, tokens.data()});
+        m_infer_requests[free_ir_index].infer();
+        std::string output = m_infer_requests[free_ir_index].get_output_tensor().data<std::string>()[0];
+
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_free_ir_indexes.push(free_ir_index);
+        return output;
+    }
+};
+*/
+
+class Tokenizer::Impl {
+    const size_t TOKENIZER_BATCH_SIZE = 1;
+    //TokenizerRunner m_tokenizer;
+    //DetokenizerRunner m_detokenizer;
+    ov::InferRequest m_tokenizer;
+    ov::InferRequest m_detokenizer;
+    std::size_t m_eos_token_id;
+    // TODO: Using multiple infer requests hang. For now we synchronize entire execution.
+    std::mutex m_tokenizer_mutex;
+    std::mutex m_detokenizer_mutex;
+
+public:
+    explicit Impl(const std::string& models_path) /*: 
+        m_tokenizer(models_path + "/openvino_tokenizer.xml"),
+        m_detokenizer(models_path + "/openvino_detokenizer.xml") */
+    {
         ov::Core core;
         core.add_extension(OPENVINO_TOKENIZERS_PATH);  // OPENVINO_TOKENIZERS_PATH is defined in CMakeLists.txt
 
@@ -29,12 +111,14 @@ public:
     }
 
     ov::Tensor encode(std::string prompt) {
+        std::unique_lock<std::mutex> lock(m_tokenizer_mutex);
         m_tokenizer.set_input_tensor(ov::Tensor{ov::element::string, {TOKENIZER_BATCH_SIZE}, &prompt});
         m_tokenizer.infer();
         return m_tokenizer.get_tensor("input_ids");
     }
 
     std::string decode(std::vector<int64_t> tokens) {
+        std::unique_lock<std::mutex> lock(m_detokenizer_mutex);
         m_detokenizer.set_input_tensor(ov::Tensor{ov::element::i64, {TOKENIZER_BATCH_SIZE, tokens.size()}, tokens.data()});
         m_detokenizer.infer();
         return m_detokenizer.get_output_tensor().data<std::string>()[0];

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/tokenizer.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/tokenizer.cpp
@@ -38,7 +38,10 @@ public:
         std::unique_lock<std::mutex> lock(m_tokenizer_mutex);
         m_tokenizer.set_input_tensor(ov::Tensor{ov::element::string, {TOKENIZER_BATCH_SIZE}, &prompt});
         m_tokenizer.infer();
-        return m_tokenizer.get_tensor("input_ids");
+        ov::Tensor tmp_tensor = m_tokenizer.get_tensor("input_ids");
+        ov::Tensor output_tensor(tmp_tensor.get_element_type(), tmp_tensor.get_shape());
+        tmp_tensor.copy_to(output_tensor);
+        return output_tensor;
     }
 
     std::string decode(std::vector<int64_t> tokens) {

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/tokenizer.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/tokenizer.cpp
@@ -3,97 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <mutex>
-#include <queue>
 #include "openvino/runtime/core.hpp"
 
 #include "tokenizer.hpp"
 
-/*
-class InferenceRunner {
-
-public:
-    std::queue<std::size_t> m_free_ir_indexes;
-    std::vector<ov::InferRequest> m_infer_requests;
-    std::shared_ptr<ov::Model> m_model;
-    std::mutex m_mutex; // protecting the free ir indexes queue
-
-    explicit InferenceRunner(std::string model_path) {
-        ov::Core core;
-        core.add_extension(OPENVINO_TOKENIZERS_PATH);  // OPENVINO_TOKENIZERS_PATH is defined in CMakeLists.txt
-        m_model = core.read_model(model_path);
-        ov::CompiledModel compiled_model = core.compile_model(m_model, "CPU");
-        for (int i = 0; i < 128; i++) {
-            m_infer_requests.push_back(compiled_model.create_infer_request());
-            m_free_ir_indexes.push(i);
-        }
-    }
-};
-
-class TokenizerRunner : public InferenceRunner {
-public:
-    using InferenceRunner::InferenceRunner;
-
-    ov::Tensor run(std::string& prompt) {
-        int free_ir_index;
-        {
-            std::unique_lock<std::mutex> lock(m_mutex);
-            free_ir_index = m_free_ir_indexes.front();
-            m_free_ir_indexes.pop();
-        }
-        m_infer_requests[free_ir_index].set_input_tensor(ov::Tensor{ov::element::string, {1}, &prompt});
-        m_infer_requests[free_ir_index].infer();
-        ov::Tensor output = m_infer_requests[free_ir_index].get_tensor("input_ids");
-
-        std::unique_lock<std::mutex> lock(m_mutex);
-        m_free_ir_indexes.push(free_ir_index);
-        return output;
-    }
-
-    std::size_t get_eos_token_id() {
-        const ov::AnyMap& rt_info = m_model->get_rt_info();
-        OPENVINO_ASSERT(rt_info.find("eos_token_id") != rt_info.end(), "Failed to detect \"eos_token_id\" in openvino_tokenizer.xml runtime information");
-        return rt_info.at("eos_token_id").as<int64_t>();
-    }
-};
-
-
-class DetokenizerRunner : public InferenceRunner {
-public:
-    using InferenceRunner::InferenceRunner;
-
-    std::string run(std::vector<int64_t>& tokens) {
-        int free_ir_index;
-        {
-            std::unique_lock<std::mutex> lock(m_mutex);
-            free_ir_index = m_free_ir_indexes.front();
-            m_free_ir_indexes.pop();
-        }
-        m_infer_requests[free_ir_index].set_input_tensor(ov::Tensor{ov::element::i64, {1, tokens.size()}, tokens.data()});
-        m_infer_requests[free_ir_index].infer();
-        std::string output = m_infer_requests[free_ir_index].get_output_tensor().data<std::string>()[0];
-
-        std::unique_lock<std::mutex> lock(m_mutex);
-        m_free_ir_indexes.push(free_ir_index);
-        return output;
-    }
-};
-*/
-
 class Tokenizer::Impl {
     const size_t TOKENIZER_BATCH_SIZE = 1;
-    //TokenizerRunner m_tokenizer;
-    //DetokenizerRunner m_detokenizer;
     ov::InferRequest m_tokenizer;
     ov::InferRequest m_detokenizer;
     std::size_t m_eos_token_id;
-    // TODO: Using multiple infer requests hang. For now we synchronize entire execution.
+    //Using multiple infer requests hangs. For now we synchronize entire execution on a single infer request.
     std::mutex m_tokenizer_mutex;
     std::mutex m_detokenizer_mutex;
 
 public:
-    explicit Impl(const std::string& models_path) /*: 
-        m_tokenizer(models_path + "/openvino_tokenizer.xml"),
-        m_detokenizer(models_path + "/openvino_detokenizer.xml") */
+    explicit Impl(const std::string& models_path)
     {
         ov::Core core;
         core.add_extension(OPENVINO_TOKENIZERS_PATH);  // OPENVINO_TOKENIZERS_PATH is defined in CMakeLists.txt

--- a/text_generation/causal_lm/cpp/continuous_batching/python/python.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/python.cpp
@@ -101,7 +101,7 @@ PYBIND11_MODULE(py_continuous_batching, m) {
         .def("get_config", &ContinuousBatchingPipeline::get_config)
         .def("add_request", &ContinuousBatchingPipeline::add_request)
         .def("step", &ContinuousBatchingPipeline::step)
-        .def("has_running_requests", &ContinuousBatchingPipeline::has_running_requests)
+        .def("has_non_finished_requests", &ContinuousBatchingPipeline::has_non_finished_requests)
         .def("generate", &ContinuousBatchingPipeline::generate);
 
     py::class_<Tokenizer, std::shared_ptr<Tokenizer>>(m, "Tokenizer")

--- a/text_generation/causal_lm/cpp/continuous_batching/python/python.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/python.cpp
@@ -89,6 +89,7 @@ PYBIND11_MODULE(py_continuous_batching, m) {
         .def(py::init<>())
         .def_readwrite("max_num_batched_tokens", &SchedulerConfig::max_num_batched_tokens)
         .def_readwrite("num_kv_blocks", &SchedulerConfig::num_kv_blocks)
+        .def_readwrite("cache_size", &SchedulerConfig::cache_size)
         .def_readwrite("block_size", &SchedulerConfig::block_size)
         .def_readwrite("cache_size", &SchedulerConfig::cache_size)
         .def_readwrite("dynamic_split_fuse", &SchedulerConfig::dynamic_split_fuse)

--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/common.py
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/common.py
@@ -241,7 +241,7 @@ def _generate_and_compare_with_reference_results(model_path: Path, prompts: List
     assert len(prompts) == len(ov_results)
 
     for prompt, ref_result, ov_result, generation_config in zip(prompts, reference_results, ov_results, generation_configs):
-        print(f"Prompt = {prompt}\nref result = {ref_result}\nOV result = {ov_result}")
+        print(f"Prompt = {prompt}\nref result = {ref_result}\nOV result = {ov_result.m_generation_ids}")
         compare_results(ref_result, ov_result, generation_config)
 
 
@@ -252,7 +252,7 @@ def generate_and_compare_with_reference_text(model_path: Path, prompts: List[str
     assert len(prompts) == len(ov_results)
 
     for prompt, ref_texts_for_this_prompt, ov_result, generation_config in zip(prompts, reference_texts_per_prompt, ov_results, generation_configs):
-        print(f"Prompt = {prompt}\nref text = {ref_texts_for_this_prompt}\nOV result = {ov_result}")
+        print(f"Prompt = {prompt}\nref text = {ref_texts_for_this_prompt}\nOV result = {ov_result.m_generation_ids}")
 
         assert len(ref_texts_for_this_prompt) == len(ov_result.m_generation_ids)
         for ref_text, ov_text in zip(ref_texts_for_this_prompt, ov_result.m_generation_ids):

--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/common.py
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/common.py
@@ -86,6 +86,7 @@ def get_test_dataset() -> Tuple[List[str], List[GenerationConfig]]:
 
 def get_scheduler_config(scheduler_params: dict = None) -> SchedulerConfig:
     scheduler_config = SchedulerConfig()
+    scheduler_config.cache_size = 1
     if scheduler_params is None:
         scheduler_config.dynamic_split_fuse = True
         # vLLM specific

--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_sampling.py
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_sampling.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from dataclasses import dataclass
 from pathlib import Path
-from py_continuous_batching import GenerationConfig, GenerationResult
+from py_continuous_batching import GenerationConfig
 from typing import List
 
 from common import run_test_pipeline, get_models_list, get_model_and_tokenizer, save_ov_model_from_optimum, \


### PR DESCRIPTION
- Introduce `GenerationHandle` to provide granular access to outputs for particular request. `GenerationHandle` is returned by the pipeline `add_request()` method and enables reading token-after-token results for that request. Useful (or even necessary) when pipeline is used in multiple threads (serving case).
- Enhance benchmark app with `request_rate` option and metrics:
	- Input throughput
	- Output throughput
	- Mean TTFT
	- Mean TPOT