### PR TITLE
Fix of problem with endless loop

### DIFF
--- a/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
@@ -6,6 +6,12 @@
 
 #include "continuous_batching_pipeline.hpp"
 
+void print_sequence(const GenerationResult& generation_result) {
+    for (size_t output_id = 0; output_id < generation_result.m_generation_ids.size(); ++output_id) {
+        std::cout << "Answer " << output_id << " (" << generation_result.m_scores[output_id] << ") : " << generation_result.m_generation_ids[output_id] << std::endl;
+    }
+}
+
 int main(int argc, char* argv[]) try {
     // Command line options
 
@@ -80,8 +86,27 @@ int main(int argc, char* argv[]) try {
         const GenerationResult & generation_result = generation_results[request_id];
 
         std::cout << "Question: " << prompts[request_id] << std::endl;
-        for (size_t output_id = 0; output_id < generation_result.m_generation_ids.size(); ++output_id) {
-            std::cout << "Answer " << output_id << " (" << generation_result.m_scores[output_id] << ") : " << generation_result.m_generation_ids[output_id] << std::endl;
+        switch (generation_result.m_status)
+        {
+        case GenerationResultStatus::FINISHED:
+            print_sequence(generation_result);
+            break;
+        case GenerationResultStatus::IGNORED:
+            std::cout << "Sequence was ignored." <<std::endl;
+            if (generation_result.m_generation_ids.size() > 0) {
+                std::cout << "Partial result:" << std::endl;
+                print_sequence(generation_result);
+            }
+            break;
+        case GenerationResultStatus::ABORTED:
+            std::cout << "Sequence was aborted." <<std::endl;
+            if (generation_result.m_generation_ids.size() > 0) {
+                std::cout << "Partial result:" << std::endl;
+                print_sequence(generation_result);
+            }
+            break;   
+        default:
+            break;
         }
         std::cout << std::endl;
     }

--- a/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/apps/accuracy_sample.cpp
@@ -6,7 +6,7 @@
 
 #include "continuous_batching_pipeline.hpp"
 
-void print_sequence(const GenerationResult& generation_result) {
+void print_generation_result(const GenerationResult& generation_result) {
     for (size_t output_id = 0; output_id < generation_result.m_generation_ids.size(); ++output_id) {
         std::cout << "Answer " << output_id << " (" << generation_result.m_scores[output_id] << ") : " << generation_result.m_generation_ids[output_id] << std::endl;
     }
@@ -89,20 +89,20 @@ int main(int argc, char* argv[]) try {
         switch (generation_result.m_status)
         {
         case GenerationResultStatus::FINISHED:
-            print_sequence(generation_result);
+            print_generation_result(generation_result);
             break;
         case GenerationResultStatus::IGNORED:
-            std::cout << "Sequence was ignored." <<std::endl;
+            std::cout << "Request was ignored due to lack of memory." <<std::endl;
             if (generation_result.m_generation_ids.size() > 0) {
                 std::cout << "Partial result:" << std::endl;
-                print_sequence(generation_result);
+                print_generation_result(generation_result);
             }
             break;
         case GenerationResultStatus::ABORTED:
-            std::cout << "Sequence was aborted." <<std::endl;
+            std::cout << "Request was aborted." <<std::endl;
             if (generation_result.m_generation_ids.size() > 0) {
                 std::cout << "Partial result:" << std::endl;
-                print_sequence(generation_result);
+                print_generation_result(generation_result);
             }
             break;   
         default:

--- a/text_generation/causal_lm/cpp/continuous_batching/library/include/continuous_batching_pipeline.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/include/continuous_batching_pipeline.hpp
@@ -9,6 +9,12 @@
 #include "tokenizer.hpp"
 #include "generation_config.hpp"
 
+enum class GenerationResultStatus {
+    FINISHED = 0,
+    IGNORED = 1,
+    ABORTED = 2 // Currently not used, TODO: implement abort functionality
+};
+
 struct GenerationResult {
     // request ID
     uint64_t m_request_id;
@@ -18,6 +24,9 @@ struct GenerationResult {
     std::vector<std::string> m_generation_ids;
     // scores
     std::vector<float> m_scores;
+
+    // Status of generation
+    GenerationResultStatus m_status;
 };
 
 class ContinuousBatchingPipeline {

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/continuous_batching_pipeline.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/continuous_batching_pipeline.cpp
@@ -24,6 +24,7 @@ GenerationResult from_sequence_group(std::shared_ptr<Tokenizer> tokenizer, Seque
         Sequence::CPtr sequence = finished_sequences[sequence_id];
 
         result.m_scores.push_back(sequence->get_beam_search_score(sequence_group->get_sampling_parameters()));
+
         {
             static ManualTimer timer("detokenize");
             timer.start();

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/continuous_batching_pipeline.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/continuous_batching_pipeline.cpp
@@ -202,6 +202,7 @@ public:
         }
 
         // perform post-processing of current step
+
         std::vector<GenerationResult> currently_finished_requests;
         {
             static ManualTimer timer("create finished results");

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/continuous_batching_pipeline.cpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/continuous_batching_pipeline.cpp
@@ -26,7 +26,7 @@ GenerationResult from_sequence_group(std::shared_ptr<Tokenizer> tokenizer, Seque
         result.m_scores.push_back(sequence->get_beam_search_score(sequence_group->get_sampling_parameters()));
 
         {
-            static ManualTimer timer("detokenize"); 
+            static ManualTimer timer("detokenize");
             timer.start();
             std::string output_text = tokenizer->decode(sequence->get_generated_ids());
             timer.end();

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
@@ -109,7 +109,7 @@ private:
             sequence_group->set_waiting();
             return m_block_manager.num_free_blocks() > prev_blocks_count;
         }
-        
+
         // currently partial preemtion is enabled only for single running sequence case
         // TODO: implement partial preemption for case with muliple sequences in group
         for (size_t s = 0; s < num_running_sequences; ++s) {

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/scheduler.hpp
@@ -57,6 +57,13 @@ public:
 
         _clear_waiting_sequences(sequence_groups);
 
+
+        // if no tokens were scheduled, we are out of memory
+        if (scheduler_output.m_total_num_scheduled_tokens == 0) {
+            for (size_t sequence_group_id = 0; sequence_group_id < sequence_groups.size(); ++sequence_group_id) {
+                sequence_groups[sequence_group_id]->set_out_of_memory();
+            }
+        }
         return scheduler_output;
     }
 

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/sequence_group.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/sequence_group.hpp
@@ -199,7 +199,7 @@ public:
     std::vector<Sequence::CPtr> get_finished_sequences() const {
         std::vector<Sequence::CPtr> finished_seqs;
         for (size_t seq_id = 0; seq_id < m_sequences.size(); ++seq_id) {
-            if (m_sequences[seq_id]->has_finished()) {
+            if (m_sequences[seq_id]->has_finished() || m_sequences[seq_id]->out_of_memory()) {
                 finished_seqs.push_back(m_sequences[seq_id]);
             }
         }
@@ -356,7 +356,7 @@ public:
         }
     }
 
-    bool out_of_memory() {
+    bool out_of_memory() const {
         for (size_t seq_id = 0; seq_id < m_sequences.size(); ++seq_id) {
             if (m_sequences[seq_id]->out_of_memory()) {
                 return true;
@@ -365,7 +365,7 @@ public:
         return false;
     }
 
-    bool is_waiting() {
+    bool is_waiting() const {
         for (size_t seq_id = 0; seq_id < m_sequences.size(); ++seq_id) {
             if (m_sequences[seq_id]->is_waiting()) {
                 return true;

--- a/text_generation/causal_lm/cpp/continuous_batching/library/src/sequence_group.hpp
+++ b/text_generation/causal_lm/cpp/continuous_batching/library/src/sequence_group.hpp
@@ -10,7 +10,9 @@
 
 enum class SequenceStatus {
     RUNNING = 0,
-    FINISHED = 1
+    FINISHED = 1,
+    OUT_OF_MEMORY = 2,
+    WAITING = 3
 };
 
 using TokenIds = std::vector<int64_t>;
@@ -63,6 +65,14 @@ public:
 
     bool is_running() const {
         return m_status == SequenceStatus::RUNNING;
+    }
+
+    bool out_of_memory() const {
+        return m_status == SequenceStatus::OUT_OF_MEMORY;
+    }
+
+    bool is_waiting() const {
+        return m_status == SequenceStatus::WAITING;
     }
 
     void set_status(SequenceStatus status) {
@@ -279,6 +289,14 @@ public:
         clear_scheduled_tokens();
     }
 
+    void clear_waiting_sequences() {
+        for (size_t seq_id = 0; seq_id < m_sequences.size(); ++seq_id) {
+            if (m_sequences[seq_id]->is_waiting()) {
+                m_sequences[seq_id]->set_status(SequenceStatus::RUNNING);
+            }
+        }
+    }
+
     const TokenIds& get_prompt_ids() const {
         return m_prompt_ids;
     }
@@ -320,5 +338,39 @@ public:
         if (m_sequences[0]->get_generated_len() > 0 || m_sequences[0]->get_cumulative_log_probs() != 0.0f)
             return false;
         return true; 
+    }
+
+    void set_out_of_memory() {
+        for (size_t seq_id = 0; seq_id < m_sequences.size(); ++seq_id) {
+            if (m_sequences[seq_id]->is_running()) {
+                m_sequences[seq_id]->set_status(SequenceStatus::OUT_OF_MEMORY);
+            }
+        }
+    }
+
+    void set_waiting() {
+        for (size_t seq_id = 0; seq_id < m_sequences.size(); ++seq_id) {
+            if (m_sequences[seq_id]->is_running()) {
+                m_sequences[seq_id]->set_status(SequenceStatus::WAITING);
+            }
+        }
+    }
+
+    bool out_of_memory() {
+        for (size_t seq_id = 0; seq_id < m_sequences.size(); ++seq_id) {
+            if (m_sequences[seq_id]->out_of_memory()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool is_waiting() {
+        for (size_t seq_id = 0; seq_id < m_sequences.size(); ++seq_id) {
+            if (m_sequences[seq_id]->is_waiting()) {
+                return true;
+            }
+        }
+        return false;
     }
 };

--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/common.py
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/common.py
@@ -237,9 +237,13 @@ def generate_and_compare_with_reference_text(model_path: Path, prompts: List[str
         for ref_text, ov_text in zip(ref_texts_for_this_prompt, ov_result.m_generation_ids):
             assert ref_text == ov_text
 
-def run_test_pipeline(tmp_path: str, model_id: str, scheduler_params: dict = None):
+def run_test_pipeline(tmp_path: str, model_id: str, scheduler_params: dict = None, generation_config = None):
     prompts, generation_configs = get_test_dataset()
     scheduler_config = get_scheduler_config(scheduler_params)
+
+    if generation_config is not None:
+        generation_config.rng_seed = 0
+        generation_configs = [generation_config] * len(prompts)
 
     _generate_and_compare_with_hf(model_id, prompts, generation_configs, scheduler_config, tmp_path)
 

--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_preemption.py
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_preemption.py
@@ -1,13 +1,54 @@
 # Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+
 import pytest
+from dataclasses import dataclass
+from py_continuous_batching import GenerationConfig, GenerationResult
+from typing import List
 
-from common import run_test_pipeline, get_models_list
+from common import get_model_and_tokenizer, save_ov_model_from_optimum, generate_and_compare_with_reference_text, \
+    DEFAULT_SCHEDULER_CONFIG, get_scheduler_config, run_test_pipeline, get_models_list, get_beam_search, get_greedy, \
+    get_multinomial_temperature_and_top_k, get_multinomial_temperature, get_multinomial_temperature_and_top_p
+from test_sampling import RandomSamplingTestStruct
 
-scheduler_params_list = [{"num_kv_blocks": 300, "block_size": 32, "dynamic_split_fuse": True, "max_num_batched_tokens": 256, "max_num_seqs": 256},
-                         {"num_kv_blocks": 40, "block_size": 4, "dynamic_split_fuse": True, "max_num_batched_tokens": 256, "max_num_seqs": 256}, # test preemption for dynamic_split_fuse
-                         {"num_kv_blocks": 40, "block_size": 4, "dynamic_split_fuse": False, "max_num_batched_tokens": 256, "max_num_seqs": 256}] # test preemption for vllm
-@pytest.mark.parametrize("scheduler_params", scheduler_params_list)
+scheduler_params_list = [({"num_kv_blocks": 2, "block_size": 32, "dynamic_split_fuse": True, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_greedy()),
+                         ({"num_kv_blocks": 2, "block_size": 32, "dynamic_split_fuse": False, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_greedy()),
+                         ({"num_kv_blocks": 34, "block_size": 32, "dynamic_split_fuse": True, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_beam_search()), # output text does not match due to <\s> symbols problem
+                         ({"num_kv_blocks": 34, "block_size": 32, "dynamic_split_fuse": False, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_beam_search())] # output text does not match due to <\s> symbols problem
+@pytest.mark.parametrize("params", scheduler_params_list)
 @pytest.mark.precommit
-def test_preemption(tmp_path, scheduler_params):
-    run_test_pipeline(tmp_path, "facebook/opt-125m", scheduler_params)
+def test_preemption(tmp_path, params):
+    run_test_pipeline(tmp_path, "facebook/opt-125m", params[0], params[1])
+
+
+@pytest.mark.precommit
+def test_out_of_memory(tmp_path):
+    with pytest.raises(RuntimeError) as excinfo:
+        run_test_pipeline(tmp_path, "facebook/opt-125m", {"num_kv_blocks": 1})
+    assert "Not enough memory for processing the requests." in str(excinfo.value)
+
+multinomial_params = RandomSamplingTestStruct(generation_config=[get_multinomial_temperature(),
+                                                          get_multinomial_temperature_and_top_p(),
+                                                          get_multinomial_temperature_and_top_k()],
+                                                       prompts=["What is OpenVINO?",
+                                                                "How are you?",
+                                                                "Tell me something about Canada?",
+                                                                ],
+                                                       ref_texts=[ ["\n\nOpenVINO is a live platform that allows users to create and manage a new library for open source applications.\n\nOpenVINO is"],
+                                                                   ["  You're getting much better results from doing this, than you are by not doing this.  I have a BH and I was so far"],
+                                                                   ["\nI'm from Canada, and I'm from the US, so I'm not sure.\nI think you mean the Canadian version.</s>"]])
+
+@pytest.mark.parametrize("dynamic_split_fuse", [True, False])
+@pytest.mark.precommit
+def test_preemption_with_multinomial(tmp_path, dynamic_split_fuse):
+    generation_configs = multinomial_params.generation_config
+    for config in generation_configs:
+        config.rng_seed = 0
+    model_id : str = "facebook/opt-125m"
+    model, hf_tokenizer = get_model_and_tokenizer(model_id, use_optimum=True)
+
+    model_path : Path = tmp_path / model_id
+    save_ov_model_from_optimum(model, hf_tokenizer, model_path)
+
+    scheduler_config = get_scheduler_config({"num_kv_blocks": 3, "block_size": 32, "dynamic_split_fuse": dynamic_split_fuse, "max_num_batched_tokens": 256, "max_num_seqs": 256})
+    generate_and_compare_with_reference_text(model_path, multinomial_params.prompts, multinomial_params.ref_texts, generation_configs, scheduler_config)

--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_preemption.py
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_preemption.py
@@ -13,8 +13,8 @@ from test_sampling import RandomSamplingTestStruct
 
 scheduler_params_list = [({"num_kv_blocks": 2, "block_size": 32, "dynamic_split_fuse": True, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_greedy()),
                          ({"num_kv_blocks": 2, "block_size": 32, "dynamic_split_fuse": False, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_greedy()),
-                         ({"num_kv_blocks": 34, "block_size": 32, "dynamic_split_fuse": True, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_beam_search()), # output text does not match due to <\s> symbols problem
-                         ({"num_kv_blocks": 34, "block_size": 32, "dynamic_split_fuse": False, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_beam_search())] # output text does not match due to <\s> symbols problem
+                         ({"num_kv_blocks": 34, "block_size": 32, "dynamic_split_fuse": True, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_beam_search()),
+                         ({"num_kv_blocks": 34, "block_size": 32, "dynamic_split_fuse": False, "max_num_batched_tokens": 256, "max_num_seqs": 256}, get_beam_search())]
 @pytest.mark.parametrize("params", scheduler_params_list)
 @pytest.mark.precommit
 def test_preemption(tmp_path, params):
@@ -36,7 +36,7 @@ multinomial_params = RandomSamplingTestStruct(generation_config=[get_multinomial
                                                                 ],
                                                        ref_texts=[ ["\n\nOpenVINO is a live platform that allows users to create and manage a new library for open source applications.\n\nOpenVINO is"],
                                                                    ["  You're getting much better results from doing this, than you are by not doing this.  I have a BH and I was so far"],
-                                                                   ["\nI'm from Canada, and I'm from the US, so I'm not sure.\nI think you mean the Canadian version.</s>"]])
+                                                                   ["\nI'm from Canada, and I'm from the US, so I'm not sure.\nI think you mean the Canadian version."]])
 
 @pytest.mark.parametrize("dynamic_split_fuse", [True, False])
 @pytest.mark.precommit

--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_preemption.py
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_preemption.py
@@ -20,13 +20,6 @@ scheduler_params_list = [({"num_kv_blocks": 2, "block_size": 32, "dynamic_split_
 def test_preemption(tmp_path, params):
     run_test_pipeline(tmp_path, "facebook/opt-125m", params[0], params[1])
 
-
-@pytest.mark.precommit
-def test_out_of_memory(tmp_path):
-    with pytest.raises(RuntimeError) as excinfo:
-        run_test_pipeline(tmp_path, "facebook/opt-125m", {"num_kv_blocks": 1})
-    assert "Not enough memory for processing the requests." in str(excinfo.value)
-
 multinomial_params = RandomSamplingTestStruct(generation_config=[get_multinomial_temperature(),
                                                           get_multinomial_temperature_and_top_p(),
                                                           get_multinomial_temperature_and_top_k()],


### PR DESCRIPTION
- Fixed endless loop in case when we can't schedule single sequence due to lack of memory, now we show informative message.
- Fixed endless loop when a sequence is preempted on generate phase, then scheduled again on prompt phase. The loop occurs as prompt phase can be processed, but for generate phase there is no space. The problem occurred for dynamic_split_fuse mode only.
 
Ticket: 141336