### PR TITLE
Pytest config

### DIFF
--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/.pytest.ini
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/.pytest.ini
@@ -1,0 +1,5 @@
+# Copyright (C) 2018-2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+[pytest]
+addopts = -m precommit

--- a/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_sampling.py
+++ b/text_generation/causal_lm/cpp/continuous_batching/python/tests/test_sampling.py
@@ -22,7 +22,7 @@ def test_sampling_precommit(tmp_path, model_id):
 def test_sampling_nightly(tmp_path, model_id):
     run_test_pipeline(tmp_path, model_id)
 
-
+@pytest.mark.real_models
 @pytest.mark.parametrize("model_id", get_models_list(os.path.join(os.path.dirname(os.path.realpath(__file__)), "models", "real_models")))
 def test_real_models(tmp_path, model_id):
     run_test_pipeline(tmp_path, model_id)


### PR DESCRIPTION
PyTest config to launch precommit tests only by default. 

real models can be launched with command:
`pytest <dir> -m real_models`